### PR TITLE
`i` is not a valid regex flag for BSD sed

### DIFF
--- a/semver.sh
+++ b/semver.sh
@@ -278,8 +278,8 @@ normalize_rules()
         | sed 's/ - /_-_/g' \
         | sed 's/\([~^<>=]\) /\1/g' \
         | sed 's/\([ _~^<>=]\)v/\1/g' \
-        | sed 's/\.[x*]//gi' \
-        | sed 's/x/*/gi' \
+        | sed 's/\.[x*]//g' \
+        | sed 's/x/*/g' \
         | sed 's/^ //g' \
         | sed 's/ $//g'
 }


### PR DESCRIPTION
Unsure if that flag is actually necessary or was included "for safety". Removing this flag is all I required in order for sh-semver to run on OS X.

Fixes #2 
