### PR TITLE
Make installable as an npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "sh-semver",
+  "version": "1.0.0",
+  "description": "The semantic versioner for Bourne Shell.",
+  "homepage": "https://github.com/qzb/sh-semver#readme",
+  "author": "Józef Sokołowski (http://qzb.me/)",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/qzb/sh-semver.git"
+  },
+  "bugs": {
+    "url": "https://github.com/qzb/sh-semver/issues"
+  },
+  "files": [ "semver.sh" ],
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "test": "tests/run.sh"
+  }
+}


### PR DESCRIPTION
Acknowledging that npm is typically thought of as a (and is primarily used for) javascript package manager, it can really be used as a package manager for anything.

npm itself has recognized and encouraged the use of npm (including the registry) as a place to publish non-javascript modules and packages. Indeed, I myself (and the entire nodenv organization),
leverage npm for managing dependencies, versioning, releases, and as a generic script/task runner for the nodenv tools and plugins (which are themselves bash/shell tools and scripts).

Which brings me to my point. The [nodenv-package-json-engine](https://github.com/nodenv/nodenv-package-json-engine) nodenv plugin depends on sh-semver (thank you, by the way!).
At present, in order to "update" the sh-semver dependency, we curl down a copy from github and commit it to our repo as a vendored dependency. If sh-semver were to include a package.json manifest (as this PR provides),
then any tools that use npm to manage their dependencies (such as nodenv) would be able to easily list sh-semver as a dependency and allow npm to manage the installation of said dependency.

It is worth noting that, while one is encouraged to actually publish sh-semver to the npm registry, publishing the module is *not* necessary for others to gain the benefit of it having a package.json manifest (thereby becoming an actual npm package). One can depend on npm packages by pointing to their git repository. Indeed, if it is desired that sh-semver not be published, I would recommend adding `"private": true` to the package.json manifest to prevent it from accidentally being published at all.

Thoughts?