### PR TITLE
Fix newline bug

### DIFF
--- a/semver.sh
+++ b/semver.sh
@@ -505,5 +505,5 @@ EOF
 done
 
 if [ -n "$output" ]; then
-    echo "$output"
+    printf '%b' "$output"
 fi

--- a/tests/output.sh
+++ b/tests/output.sh
@@ -1,0 +1,3 @@
+describe 'Command output (printing)'
+    RET=$(./semver.sh -r '^4.0.0' 4.0.0 4.2.1 | tail -1)
+    assert "$RET" "4.2.1" '"\\n" should be printed as newlines'

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -60,11 +60,9 @@ summary()
 # Import specs
 . ./tests/tests.sh
 . ./tests/strict_rules_tests.sh
+. ./tests/output.sh
 #. ./tests/node_semver_tests.sh
 
 
 # Summarize
 summary
-
-
-


### PR DESCRIPTION
When the output of semver.sh should be multiple lines, the output was incorrectly escaping the \n character.

Bug introduced by fff3821c052aac9e20dd8ee9217df3b3daf7e5ac

Test added to demonstrate bug (added in a new file/suite intended to contain end-to-end or output/printing tests).