### PR TITLE
Sorting versions from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,18 @@
 
 The semantic versioner for Bourne Shell.
 
+## CLI
+
+```
+semver.sh [-r <rule>] [<version>... ]
+```
+
+Given a rule and one or many versions, it will return all of the provided versions that satisfy the rule, in sorted order, one per line.
+
+If versions are omitted from the command line, it will read them from STDIN.
+
+If the rule is omitted from the command line, it will simply sort all the provided versions.
+
 ## Ranges
 
 Every *version range* contains one or more *sets of comparators*. To satisfy *version range* version must satisfies all *comparators* from at least one set. Sets are separated with two vertical bars ``||``. Rules in each set are separated with whitespaces. Empty set are treated as wildcard comparator ``*``.

--- a/semver.sh
+++ b/semver.sh
@@ -490,7 +490,11 @@ apply_rules()
 
 
 FORCE_ALLOW_PREREL=false
-USAGE="Usage:    $0 -r <rule> <version> [<version>... ]"
+USAGE="Usage:    $0 [-r <rule>] [<version>... ]
+
+Omitting <version>s reads them from STDIN.
+Omitting -r <rule> simply sorts the versions according to semver ordering."
+
 while getopts ar:h o; do
     case "$o" in
         a) FORCE_ALLOW_PREREL=true ;;

--- a/semver.sh
+++ b/semver.sh
@@ -489,16 +489,14 @@ apply_rules()
 
 
 
-if [ $# -eq 0 ]; then
-    echo "Usage:    $0 -r <rule> <version> [<version>... ]"
-fi
-
 FORCE_ALLOW_PREREL=false
+USAGE="Usage:    $0 -r <rule> <version> [<version>... ]"
 while getopts ar:h o; do
     case "$o" in
         a) FORCE_ALLOW_PREREL=true ;;
         r) RULES_STRING="$OPTARG||";;
-        h|?) echo "Usage:    $0 -r <rule> <version> [<version>... ]"
+        h) echo "$USAGE" && exit ;;
+        ?) echo "$USAGE" && exit 1;;
     esac
 done
 

--- a/semver.sh
+++ b/semver.sh
@@ -502,7 +502,9 @@ done
 
 shift $(( OPTIND-1 ))
 
+VERSIONS=( ${@:-$(cat -)} )
+
 # Sort versions
-VERSIONS=( $(semver_sort "$@") )
+VERSIONS=( $(semver_sort "${VERSIONS[@]}") )
 
 apply_rules "$RULES_STRING" "${VERSIONS[@]}"

--- a/semver.sh
+++ b/semver.sh
@@ -507,4 +507,8 @@ VERSIONS=( ${@:-$(cat -)} )
 # Sort versions
 VERSIONS=( $(semver_sort "${VERSIONS[@]}") )
 
-apply_rules "$RULES_STRING" "${VERSIONS[@]}"
+if [ -z "$RULES_STRING" ]; then
+  printf '%s\n' "${VERSIONS[@]}"
+else
+  apply_rules "$RULES_STRING" "${VERSIONS[@]}"
+fi

--- a/semver.sh
+++ b/semver.sh
@@ -417,25 +417,6 @@ rule_all()
     return 0
 }
 
-
-if [ $# -eq 0 ]; then
-    echo "Usage:    $0 -r <rule> <version> [<version>... ]"
-fi
-
-FORCE_ALLOW_PREREL=false
-while getopts ar:h o; do
-    case "$o" in
-        a) FORCE_ALLOW_PREREL=true ;;
-        r) RULES_STRING="$OPTARG||";;
-        h|?) echo "Usage:    $0 -r <rule> <version> [<version>... ]"
-    esac
-done
-
-shift $(( OPTIND-1 ))
-
-# Sort versions
-VERSIONS=( $(semver_sort "$@") )
-
 apply_rules()
 {
   local rules_string="$1"
@@ -505,5 +486,25 @@ for ver in "${versions[@]}"; do
     group=$(( group + 1 ))
 done
 }
+
+
+
+if [ $# -eq 0 ]; then
+    echo "Usage:    $0 -r <rule> <version> [<version>... ]"
+fi
+
+FORCE_ALLOW_PREREL=false
+while getopts ar:h o; do
+    case "$o" in
+        a) FORCE_ALLOW_PREREL=true ;;
+        r) RULES_STRING="$OPTARG||";;
+        h|?) echo "Usage:    $0 -r <rule> <version> [<version>... ]"
+    esac
+done
+
+shift $(( OPTIND-1 ))
+
+# Sort versions
+VERSIONS=( $(semver_sort "$@") )
 
 apply_rules "$RULES_STRING" "${VERSIONS[@]}"

--- a/tests/input.sh
+++ b/tests/input.sh
@@ -1,0 +1,10 @@
+describe 'Command input'
+    RET=$(echo 4.0.0 4.2.1 5.0.0 | ./semver.sh -r '^4.0.0')
+    assert "$RET" "4.0.0\\n4.2.1" 'should accept versions on STDIN'
+
+describe 'When not given a rule'
+    RET=$(./semver.sh 4.2.1 4.0.0 3.1.2 5.0.0)
+    assert "$RET" "3.1.2\\n4.0.0\\n4.2.1\\n5.0.0" 'should sort versions'
+
+    RET=$(echo 4.2.1 4.0.0 3.1.2 5.0.0 | ./semver.sh)
+    assert "$RET" "3.1.2\\n4.0.0\\n4.2.1\\n5.0.0" 'should sort versions from STDIN'

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -58,6 +58,7 @@ summary()
 
 
 # Import specs
+. ./tests/input.sh
 . ./tests/tests.sh
 . ./tests/strict_rules_tests.sh
 . ./tests/output.sh

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -54,7 +54,7 @@ summary()
 
 
 # Import semver
-. ./semver.sh
+. ./semver.sh < <(echo) # need to provide some stdin since no args are provided
 
 
 # Import specs


### PR DESCRIPTION
closes #11 

This PR looks bigger than it really is. The main body of the script (looping over versions) has been wrapped in a function and indented. The commits in this PR have been kept distinct to allow reviewing the PR commit-by-commit. (The function wrapping, moving of function, and indentation of function have each been committed separately so the actual changes can be reviewed separately from the noise of the move+indent.)

I'll let each of the commit summaries speak for themselves.