### PR TITLE
Replace travisci with GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule: { interval: monthly }
+    cooldown: { default-days: 15 }
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule: { interval: monthly }
+    cooldown: { default-days: 15 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Test
+on:
+  push:
+  pull_request:
+  schedule: [{ cron: "0 0 10 * *" }] # monthly https://crontab.guru/#0_0_10_*_*
+  workflow_dispatch:
+
+permissions: { contents: read }
+jobs:
+  npm-cit:
+    runs-on: ${{ matrix.os }}-latest
+    strategy: { matrix: { os: [ubuntu, macOS] } }
+    steps:
+      - uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with: { egress-policy: audit }
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - run: npm cit
+
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with: { egress-policy: audit }
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: sh
-script:
-    - ./tests/run.sh

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # sh-semver
 
-[![NPM Version][npm-image]][npm-url]
-[![Build][travis-image]][travis-url]
-
 The semantic versioner for Bourne Shell.
+
+[![NPM Version][npm-image]][npm-url]
+[![Test status][gha-image]][gha-url]
 
 ## CLI
 
@@ -69,5 +69,5 @@ Prerelease versions can satisfy comparators set only when have the same minor ma
 
 [npm-image]: https://img.shields.io/npm/v/sh-semver.svg
 [npm-url]: https://npmjs.org/package/sh-semver.sh
-[travis-image]: https://travis-ci.org/qzb/sh-semver.svg?branch=master
-[travis-url]: https://travis-ci.org/qzb/sh-semver
+[gha-image]: https://github.com/qzb/sh-semver/actions/workflows/test.yml/badge.svg
+[gha-url]: https://github.com/qzb/sh-semver/actions/workflows/test.yml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,16 @@
+{
+  "name": "sh-semver",
+  "version": "1.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sh-semver",
+      "version": "1.1.0",
+      "license": "MIT",
+      "bin": {
+        "sh-semver": "semver.sh"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Uses a simple `npm cit` command for ci installation and running the npm-test command. (Which also necessitates the addition of package-lock.json.)

Runs tests on push and pull events. (Push allows tests to run against branches that aren't even opened for PR. Also ensures tests run on tag events, and anything that lands on default branch.) Simple configuration is a bonus. It means "normal" PR branches will get duplicate test runs, but they actually run against different shas. (PR runs against the MERGE_HEAD whereas push runs against the branch HEAD) This can be valuable insight if only _one_ of those jobs fail. Also configured to run on workflow_dispatch events so they can be manually triggered through the github web UI or cli if necessary. Also runs on a cron schedule. This is helpful for projects that don't see a lot of activity, because it will ensure any _action_ related deprecation warnings will be caught sooner. Otherwise it can be months or years before another PR is opened to trigger the workflow.

Removes the travis configuration and updates the README build/test badge. (Also moves the badges below the description which makes the repo more consumable when repo URLs are unfurled by social sharing services, etc.)

Runs of this workflow can be found on the fork: https://github.com/jasonkarns/sh-semver/actions/runs/16526098577

## Security considerations

This workflow pins actions to precise SHAs (rather than using branch or tag refs that can change underneath us or be compromised). This is the more secure and recommended approach. To ensure that the actions themselves get bumped, dependabot configuration is added and enabled. (Dependabot will also bump the trailing human-readable version comment next to each action SHA, so humans can see what the version actually is without needing to dereference the commit SHA.)

The workflows leverage the harden-runner action, which will audit any network activity of the actions. Presently, it's in audit mode and prints a report Job Summary:
<img width="1231" height="415" alt="image" src="https://github.com/user-attachments/assets/cac5964d-0e41-4a57-9d9c-b6673c91336b" />

Future enhancements can be made to lock down network activity to the minimal hosts necessary.

Also includes dependency-review action which will provide a report (Job Summary) for any dependency changes. This will serve to surface any dependency changes that try to sneak in via PR.